### PR TITLE
Improve reliance on serialized data

### DIFF
--- a/android/src/main/java/es/danirod/rectball/android/AndroidPlatform.java
+++ b/android/src/main/java/es/danirod/rectball/android/AndroidPlatform.java
@@ -29,8 +29,8 @@ import es.danirod.rectball.platform.*;
 import es.danirod.rectball.platform.LegacyScores;
 import es.danirod.rectball.platform.Scores;
 import es.danirod.rectball.platform.Sharing;
-import es.danirod.rectball.platform.LegacyStatistics;
-import es.danirod.rectball.platform.Statistics;
+import es.danirod.rectball.platform.LegacyStats;
+import es.danirod.rectball.platform.Stats;
 
 /**
  * This contains code for the Android platform. Here code that uses Android
@@ -48,7 +48,7 @@ public class AndroidPlatform implements Platform {
 
     private final Preferences preferences;
 
-    private final Statistics statistics;
+    private final Stats stats;
 
     private final AndroidApplication app;
 
@@ -62,7 +62,7 @@ public class AndroidPlatform implements Platform {
                 return Gdx.files.local("scores");
             }
         };
-        statistics = new LegacyStatistics() {
+        stats = new LegacyStats() {
             @Override
             protected FileHandle getStatistics() {
                 return Gdx.files.local("stats");
@@ -87,8 +87,8 @@ public class AndroidPlatform implements Platform {
     }
 
     @Override
-    public Statistics statistics() {
-        return statistics;
+    public Stats stats() {
+        return stats;
     }
 
     @Override

--- a/core/src/main/java/es/danirod/rectball/RectballGame.java
+++ b/core/src/main/java/es/danirod/rectball/RectballGame.java
@@ -130,7 +130,7 @@ public class RectballGame extends Game {
     public void finishLoading() {
         // Load the remaining data.
         platform.score().readData();
-        statistics = platform.statistics().loadStatistics();
+        statistics = platform.stats().loadStatistics();
         player = new SoundPlayer(this);
         uiSkin = new RectballSkin(this);
         updateBallAtlas();

--- a/core/src/main/java/es/danirod/rectball/model/Statistics.java
+++ b/core/src/main/java/es/danirod/rectball/model/Statistics.java
@@ -51,7 +51,7 @@ public class Statistics {
     }
 
     /**
-     * Group of related statistics. This class groups some related stats so that
+     * Group of related stats. This class groups some related stats so that
      * they can be stored together in the serialized file.
      */
     public static class StatisticSet {

--- a/core/src/main/java/es/danirod/rectball/platform/LegacyStats.java
+++ b/core/src/main/java/es/danirod/rectball/platform/LegacyStats.java
@@ -21,18 +21,20 @@ package es.danirod.rectball.platform;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.utils.*;
 
+import es.danirod.rectball.model.Statistics;
+
 /**
  * @author danirod
  */
-public abstract class LegacyStatistics implements Statistics {
+public abstract class LegacyStats implements Stats {
 
     @Override
-    public void saveStatistics(es.danirod.rectball.model.Statistics statistics) {
+    public void saveStatistics(Statistics statistics) {
         Json json = new Json();
         json.setOutputType(JsonWriter.OutputType.json);
         String jsonData = json.toJson(statistics);
 
-        // Encode statistics in Base64 and save it to a file.
+        // Encode stats in Base64 and save it to a file.
         String encodedJson = Base64Coder.encodeString(jsonData);
         FileHandle handle;
         handle = getStatistics();
@@ -40,30 +42,30 @@ public abstract class LegacyStatistics implements Statistics {
     }
 
     @Override
-    public es.danirod.rectball.model.Statistics loadStatistics() {
+    public Statistics loadStatistics() {
         try {
             // Read stats from file and decode them.
             FileHandle handle = getStatistics();
             String encodedJson = handle.readString();
             String decodedJson = Base64Coder.decodeString(encodedJson);
 
-            // Convert JSON to statistics
+            // Convert JSON to stats
             JsonReader reader = new JsonReader();
             JsonValue rootStats = reader.parse(decodedJson);
-            es.danirod.rectball.model.Statistics.StatisticSet total = parseTotal(rootStats);
-            es.danirod.rectball.model.Statistics.StatisticSet colors = parseColor(rootStats);
-            es.danirod.rectball.model.Statistics.StatisticSet sizes = parseSizes(rootStats);
-            return new es.danirod.rectball.model.Statistics(total, colors, sizes);
+            Statistics.StatisticSet total = parseTotal(rootStats);
+            Statistics.StatisticSet colors = parseColor(rootStats);
+            Statistics.StatisticSet sizes = parseSizes(rootStats);
+            return new Statistics(total, colors, sizes);
         } catch (Exception ex) {
-            return new es.danirod.rectball.model.Statistics();
+            return new Statistics();
         }
     }
 
     protected abstract FileHandle getStatistics();
 
-    es.danirod.rectball.model.Statistics.StatisticSet parseTotal(JsonValue root) {
+    Statistics.StatisticSet parseTotal(JsonValue root) {
         JsonValue total = root.get("total").get("values");
-        es.danirod.rectball.model.Statistics.StatisticSet stat = new es.danirod.rectball.model.Statistics.StatisticSet();
+        Statistics.StatisticSet stat = new Statistics.StatisticSet();
         stat.incrementValue("score", total.getInt("score"));
         stat.incrementValue("combinations", total.getInt("combinations"));
         stat.incrementValue("balls", total.getInt("balls"));
@@ -72,9 +74,9 @@ public abstract class LegacyStatistics implements Statistics {
         return stat;
     }
 
-    es.danirod.rectball.model.Statistics.StatisticSet parseColor(JsonValue root) {
+    Statistics.StatisticSet parseColor(JsonValue root) {
         JsonValue color = root.get("colors").get("values");
-        es.danirod.rectball.model.Statistics.StatisticSet stat = new es.danirod.rectball.model.Statistics.StatisticSet();
+        Statistics.StatisticSet stat = new Statistics.StatisticSet();
         stat.incrementValue("red", color.getInt("red"));
         stat.incrementValue("blue", color.getInt("blue"));
         stat.incrementValue("green", color.getInt("green"));
@@ -82,9 +84,9 @@ public abstract class LegacyStatistics implements Statistics {
         return stat;
     }
 
-    es.danirod.rectball.model.Statistics.StatisticSet parseSizes(JsonValue root) {
+    Statistics.StatisticSet parseSizes(JsonValue root) {
         JsonValue sizes = root.get("sizes").get("values");
-        es.danirod.rectball.model.Statistics.StatisticSet stat = new es.danirod.rectball.model.Statistics.StatisticSet();
+        Statistics.StatisticSet stat = new Statistics.StatisticSet();
         JsonValue.JsonIterator size = sizes.iterator();
         while (size.hasNext()) {
             JsonValue val = size.next();

--- a/core/src/main/java/es/danirod/rectball/platform/Platform.java
+++ b/core/src/main/java/es/danirod/rectball/platform/Platform.java
@@ -43,7 +43,7 @@ public interface Platform {
 
     Preferences preferences();
 
-    Statistics statistics();
+    Stats stats();
 
     void toast(CharSequence msg);
 }

--- a/core/src/main/java/es/danirod/rectball/platform/Stats.java
+++ b/core/src/main/java/es/danirod/rectball/platform/Stats.java
@@ -21,7 +21,7 @@ package es.danirod.rectball.platform;
 /**
  * @author danirod
  */
-public interface Statistics {
+public interface Stats {
 
     es.danirod.rectball.model.Statistics loadStatistics();
 

--- a/core/src/main/java/es/danirod/rectball/scene2d/ui/StatsTable.java
+++ b/core/src/main/java/es/danirod/rectball/scene2d/ui/StatsTable.java
@@ -107,7 +107,7 @@ public class StatsTable extends Table {
         }
 
         for (Map.Entry<String, Integer> stat : set.getStats().entrySet()) {
-            String statName = game.getLocale().get("statistics.total." + stat.getKey());
+            String statName = game.getLocale().get("stats.total." + stat.getKey());
             String statValue = Integer.toString(stat.getValue());
 
             if (stat.getKey().equals("time")) {

--- a/core/src/main/java/es/danirod/rectball/screens/GameScreen.java
+++ b/core/src/main/java/es/danirod/rectball/screens/GameScreen.java
@@ -525,11 +525,11 @@ public class GameScreen extends AbstractScreen implements TimerCallback, BallSel
         game.getPlatform().score().registerScore(score, time);
         game.getPlatform().score().flushData();
 
-        // Save information about this game in the statistics.
+        // Save information about this game in the stats.
         game.statistics.getTotalData().incrementValue("score", game.getState().getScore());
         game.statistics.getTotalData().incrementValue("games");
         game.statistics.getTotalData().incrementValue("time", Math.round(game.getState().getElapsedTime()));
-        game.getPlatform().statistics().saveStatistics(game.statistics);
+        game.getPlatform().stats().saveStatistics(game.statistics);
 
         // Mark a combination that the user could do if he had enough time.
         if (game.getState().getWiggledBounds() == null) {

--- a/core/src/main/java/es/danirod/rectball/screens/StatisticsScreen.java
+++ b/core/src/main/java/es/danirod/rectball/screens/StatisticsScreen.java
@@ -38,7 +38,7 @@ import es.danirod.rectball.scene2d.listeners.ScreenPopper;
 import es.danirod.rectball.scene2d.ui.StatsTable;
 
 /**
- * Statistics screen.
+ * Stats screen.
  */
 public class StatisticsScreen extends AbstractScreen {
 

--- a/desktop/src/main/java/es/danirod/rectball/desktop/DesktopPlatform.java
+++ b/desktop/src/main/java/es/danirod/rectball/desktop/DesktopPlatform.java
@@ -27,8 +27,8 @@ import es.danirod.rectball.platform.*;
 import es.danirod.rectball.platform.LegacyScores;
 import es.danirod.rectball.platform.Scores;
 import es.danirod.rectball.platform.Sharing;
-import es.danirod.rectball.platform.LegacyStatistics;
-import es.danirod.rectball.platform.Statistics;
+import es.danirod.rectball.platform.LegacyStats;
+import es.danirod.rectball.platform.Stats;
 
 /**
  * This contains code for desktop platform. Here code that uses desktop JRE
@@ -46,7 +46,7 @@ public class DesktopPlatform implements Platform {
 
     private Preferences preferences;
 
-    private Statistics statistics;
+    private Stats stats;
 
     protected DesktopPlatform() {
         sharing = new DesktopSharing();
@@ -66,7 +66,7 @@ public class DesktopPlatform implements Platform {
             }
         };
         preferences = new LwjglPreferences("rectball", ".prefs/");
-        statistics = new LegacyStatistics() {
+        stats = new LegacyStats() {
             @Override
             protected FileHandle getStatistics() {
                 if (SharedLibraryLoader.isWindows) {
@@ -99,8 +99,8 @@ public class DesktopPlatform implements Platform {
     }
 
     @Override
-    public Statistics statistics() {
-        return statistics;
+    public Stats stats() {
+        return stats;
     }
 
     @Override


### PR DESCRIPTION
Issues like #66 prove that it is dangerous to serialize things without controlling changes in Schema.

Statistics, settings and scores serialization should be better stored and should be tested to make sure that it works. Otherwise, the data that the user is storing could be corrupted, compromised or somehow deleted.
